### PR TITLE
Update index.html with py5 new domain name

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,7 +362,7 @@ href="https://github.com/thonny/thonny/releases">https://github.com/thonny/thonn
     <li><a href="https://pypi.org/project/thonny-onedark/">thonny-onedark</a> adds One Dark syntax theme.</li>
     <li><a href="https://pypi.org/project/thonny-crosshair/">thonny-crosshair</a> adds commands for invoking <a href="https://github.com/pschanely/CrossHair">CrossHair analyzer</a>.</li>
     <li><a href="https://pypi.org/project/thonny-icontract-hypothesis/">thonny-icontract-hypothesis</a> adds commands for invoking <a href="https://github.com/mristin/icontract-hypothesis">icontract-hypothesis analyzer</a>.</li>
-    <li><a href="https://pypi.org/project/thonny-py5mode/">thonny-py5mode</a> adds <a href="https://py5.ixora.io/">py5</a> support for a Processing-like creative coding environment.</li>
+    <li><a href="https://pypi.org/project/thonny-py5mode/">thonny-py5mode</a> adds <a href="https://py5coding.org/">py5</a> support for a Processing-like creative coding environment.</li>
     <li><a href="https://pypi.org/project/ThonnyFlake8/">ThonnyFlake8</a> adds warnings from <a href="https://github.com/PyCQA/flake8">flake8</a>.</li>
 </ul>
 


### PR DESCRIPTION
Updated link for the new py5coding.org domain name.

Thank you for your support!
