### PR TITLE
Rename ThonnyFlake8 to thonny-flake

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,7 +435,7 @@ href="https://github.com/thonny/thonny/releases">https://github.com/thonny/thonn
     <li><a href="https://pypi.org/project/thonny-crosshair/">thonny-crosshair</a> adds commands for invoking <a href="https://github.com/pschanely/CrossHair">CrossHair analyzer</a>.</li>
     <li><a href="https://pypi.org/project/thonny-icontract-hypothesis/">thonny-icontract-hypothesis</a> adds commands for invoking <a href="https://github.com/mristin/icontract-hypothesis">icontract-hypothesis analyzer</a>.</li>
     <li><a href="https://pypi.org/project/thonny-py5mode/">thonny-py5mode</a> adds <a href="https://py5coding.org/">py5</a> support for a Processing-like creative coding environment.</li>
-    <li><a href="https://pypi.org/project/ThonnyFlake8/">ThonnyFlake8</a> adds warnings from <a href="https://github.com/PyCQA/flake8">flake8</a>.</li>
+    <li><a href="https://pypi.org/project/thonny-flake/">thonny-flake</a> adds warnings from <a href="https://github.com/PyCQA/flake8">flake8</a>.</li>
     <li><a href="https://pypi.org/project/thonny-autosave/">thonny-autosave</a> adds the option for auto-saving your script in every 10 seconds.</li>
 </ul>
 


### PR DESCRIPTION
This fits with plugin name guidelines that I missed when I added it: 

> In short: the same way as you would package and distribute any Python module or package. Just make sure your distribution name starts with `thonny-` and you have specified supported Thonny version range under dependencies.

From https://github.com/thonny/thonny/wiki/Plugins#how-to-package-and-distribute-your-plug-in

I have renamed the package to fit this (I could not change it to `thonny-flake8` due to pypi's "too similar" name rules).

